### PR TITLE
A fix for a date bug, pinning Docker image versions

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -103,6 +103,7 @@ def sparql():
     if not 'query' in request.args:
         return "Query parameter 'query' is required", BAD_REQUEST_STATUS
     query = request.args['query']
+    logger.debug(query)
     result = GleanerSearch(
         endpoint_url=app.config['GLEANER_ENDPOINT_URL']).pass_through_query(query)
     return result

--- a/app/search/dataone.py
+++ b/app/search/dataone.py
@@ -154,10 +154,19 @@ class SolrDirectSearch(SearcherBase):
             # convert from dates as represented by Solr
             # See https://solr.apache.org/guide/6_6/working-with-dates.html
 
-            begin = datetime.fromisoformat(result.pop('beginDate').rstrip('Z'))
-            end = datetime.fromisoformat(result.pop('endDate').rstrip('Z'))
-            result['temporal_coverage'] = datetime.date(
-                begin).isoformat() + "/" + datetime.date(end).isoformat()
+            # These values are shown in the UI; provide sensible defaults
+            begin  = "Unknown"
+            end = "Unknown"
+            try:
+                begin = datetime.date(datetime.fromisoformat(result.pop('beginDate').rstrip('Z'))).isoformat()
+            except ValueError as ve:
+                logger.error("Invalid start date in dataone result: %s %s", urls[0], ve)
+            try:
+                end = datetime.date(datetime.fromisoformat(result.pop('endDate').rstrip('Z'))).isoformat()
+            except ValueError as ve:
+                logger.error("Invalid end date in dataone result: %s %s", urls[0], ve)
+
+            result['temporal_coverage'] = begin + "/" + end
 
         boundingbox = {'south': result.pop('southBoundCoord', None), 'north': result.pop(
             'northBoundCoord', None), 'west': result.pop('westBoundCoord', None), 'east': result.pop('eastBoundCoord', None)}

--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -536,6 +536,7 @@ class GleanerSearch(SearcherBase):
 
     def pass_through_query(self, query):
         self.query = query
+        logger.debug(self.query)
         self.sparql.setQuery(query)
 
         if self.sparql.isSparqlUpdateRequest():

--- a/deployment-support/gleaner/docker.yaml
+++ b/deployment-support/gleaner/docker.yaml
@@ -52,7 +52,7 @@ sources:
   active: true
 - name: gcmd
   type: sitemap
-  headless: false
+  headless: true
   url: http://s3system:9000/sitemaps/gcmd-sitemap.xml
   properName: Global Change Master Directory
   active: true

--- a/deployment-support/gleaner/docker.yaml
+++ b/deployment-support/gleaner/docker.yaml
@@ -78,3 +78,10 @@ sources:
   properName: DataStream
   domain: http://datastream.org
   active: true
+- name: ant-nz
+  type: sitemap
+  headless: false
+  url: https://ant-nz.geodata.nz/geonetwork/srv/api/0.1/sitemap
+  properName: Antarctica New Zealand
+  domain: https://ant-nz.geodata.nz/geonetwork
+  active: false

--- a/deployment-support/gleaner/docker.yaml
+++ b/deployment-support/gleaner/docker.yaml
@@ -38,7 +38,7 @@ sources:
   active: true
 - name: bas
   type: sitemap
-  headless: true
+  headless: false
   url: http://s3system:9000/sitemaps/bas-sitemap.xml
   properName: British Antarctic Survey
   active: true
@@ -70,7 +70,7 @@ sources:
   properName: pdc
   domain: http://hedeby.uwaterloo.ca
   apipagelimit: 500
-  active: true
+  active: false
 - name: datastream
   type: sitemap
   headless: false
@@ -81,7 +81,7 @@ sources:
 - name: ant-nz
   type: sitemap
   headless: false
-  url: https://ant-nz.geodata.nz/geonetwork/srv/api/0.1/sitemap
+  url: https://ant-nz.geodata.nz/geonetwork/srv/api/0.1/sitemap?format=jsonld
   properName: Antarctica New Zealand
   domain: https://ant-nz.geodata.nz/geonetwork
-  active: false
+  active: true

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -115,11 +115,12 @@ services:
     command: ["server", "/data", "--console-address", ":54321"]
 
   headless:
-    image: chromedp/headless-shell:stable
+    image: chromedp/headless-shell:104.0.5098.0
     ports:
       - 9222:9222
     environment:
      - SERVICE_PORTS=9222
+    command: --disable-gpu
 
   write-to-triplestore:
     image: minio/mc:RELEASE.2022-11-17T21-20-39Z

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -5,7 +5,7 @@ volumes:
 services:
 
   gleaner-setup:
-    image: nsfearthcube/gleaner:v3.0.8
+    image: nsfearthcube/gleaner:dev-v3.0.8
     command: -cfg docker -setup
     depends_on:
       - triplestore
@@ -61,7 +61,7 @@ services:
       - MINIO_ROOT_PASSWORD=${MINIO_SECRET_KEY}
 
   gleaner:
-    image: nsfearthcube/gleaner:v3.0.8
+    image: nsfearthcube/gleaner:dev-v3.0.8
     command: -cfg docker
     depends_on:
       - triplestore
@@ -115,12 +115,11 @@ services:
     command: ["server", "/data", "--console-address", ":54321"]
 
   headless:
-    image: chromedp/headless-shell:104.0.5098.0
+    image: chromedp/headless-shell:109.0.5414.10
     ports:
       - 9222:9222
     environment:
      - SERVICE_PORTS=9222
-    command: --disable-gpu
 
   write-to-triplestore:
     image: minio/mc:RELEASE.2022-11-17T21-20-39Z

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.47.0"
+appVersion: "1.48.0"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -113,7 +113,7 @@ Partials for commonly used containers
 */}}
 {{- define "gleaner-index" }}
 - name: gleaner-index
-  image: nsfearthcube/gleaner:v3.0.8
+  image: nsfearthcube/gleaner:dev-v3.0.8
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   args:
   - -cfg

--- a/helm/templates/gleaner-config.yaml
+++ b/helm/templates/gleaner-config.yaml
@@ -77,7 +77,7 @@ data:
       properName: pdc
       domain: http://hedeby.uwaterloo.ca
       apipagelimit: 500
-      active: true
+      active: false
     - name: datastream
       type: sitemap
       headless: false

--- a/helm/templates/gleaner-config.yaml
+++ b/helm/templates/gleaner-config.yaml
@@ -85,3 +85,10 @@ data:
       properName: DataStream
       domain: http://datastream.org
       active: true
+    - name: ant-nz
+      type: sitemap
+      headless: false
+      url: https://ant-nz.geodata.nz/geonetwork/srv/api/0.1/sitemap
+      properName: Antarctica New Zealand
+      domain: https://ant-nz.geodata.nz/geonetwork
+      active: false

--- a/helm/templates/gleaner-config.yaml
+++ b/helm/templates/gleaner-config.yaml
@@ -59,7 +59,7 @@ data:
       active: true
     - name: gcmd
       type: sitemap
-      headless: false
+      headless: true
       url: http://s3system-svc:{{ .Values.s3system_service.api_port }}/sitemaps/gcmd-sitemap.xml
       properName: Global Change Master Directory
       active: true

--- a/helm/templates/gleaner-config.yaml
+++ b/helm/templates/gleaner-config.yaml
@@ -91,4 +91,4 @@ data:
       url: https://ant-nz.geodata.nz/geonetwork/srv/api/0.1/sitemap
       properName: Antarctica New Zealand
       domain: https://ant-nz.geodata.nz/geonetwork
-      active: false
+      active: true

--- a/helm/templates/gleaner-deployment.yaml
+++ b/helm/templates/gleaner-deployment.yaml
@@ -117,14 +117,13 @@ spec:
         - name: MINIO_API_TRANSITION_WORKERS
           value: "{{ .Values.MINIO_WORKERS }}"
       - name: headless
-        image: chromedp/headless-shell::104.0.5098.0
+        image: chromedp/headless-shell:109.0.5414.10
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.headless_service.port }}
         env:
         - name: SERVICE_PORTS
           value: "{{ .Values.headless_service.port }}"
-        args: --disable-gpu
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/gleaner-deployment.yaml
+++ b/helm/templates/gleaner-deployment.yaml
@@ -117,13 +117,14 @@ spec:
         - name: MINIO_API_TRANSITION_WORKERS
           value: "{{ .Values.MINIO_WORKERS }}"
       - name: headless
-        image: chromedp/headless-shell:stable
+        image: chromedp/headless-shell::104.0.5098.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.headless_service.port }}
         env:
         - name: SERVICE_PORTS
           value: "{{ .Values.headless_service.port }}"
+        args: --disable-gpu
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/setup-gleaner.yaml
+++ b/helm/templates/setup-gleaner.yaml
@@ -57,7 +57,7 @@ spec:
               name: {{ .Release.Name }}-secrets
       # Run gleaner setup, which creates cloud storage buckets
       - name: gleaner-setup
-        image: nsfearthcube/gleaner:v3.0.8
+        image: nsfearthcube/gleaner:dev-v3.0.8
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - -cfg

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polder-federated-search",
   "license": "BSD-3-Clause",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "description": "A federated search for the polar research community",
   "author": "Melinda Minch <melindaminch@oceannetworks.ca>",
   "repository": "https://github.com/WDS-ITO/polder-federated-search",


### PR DESCRIPTION
The main change here is that we got some invalid ISO dates and it made the site crash, so this guards against that. Also, later versions of Chrome headless are causing problems with the Gleaner toolchain, so I pinned the version of that image to a specific version.